### PR TITLE
Add ability to expose port 8089 for UDP services

### DIFF
--- a/influxdb/config.json
+++ b/influxdb/config.json
@@ -16,11 +16,13 @@
   "boot": "auto",
   "ports": {
     "80/tcp": null,
-    "8086/tcp": 8086
+    "8086/tcp": 8086,
+    "8089/udp": 8089
   },
   "ports_description": {
     "80/tcp": "Web interface (Not required for Ingress)",
-    "8086/tcp": "InfluxDB server"
+    "8086/tcp": "InfluxDB server",
+    "8089/udp": "InfluxDB UDP service port"
   },
   "hassio_api": true,
   "auth_api": true,


### PR DESCRIPTION
8089 is the default port that runs the UDP service. Can be used by some applications like Proxmox.

# Proposed Changes

> Add ability to expose port 8089 for UDP services

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://github.com/hassio-addons/addon-influxdb/issues/39